### PR TITLE
Fix enum models #build_from_hash

### DIFF
--- a/lib/merge_ticketing_client/models/account_details_and_actions_status_enum.rb
+++ b/lib/merge_ticketing_client/models/account_details_and_actions_status_enum.rb
@@ -39,7 +39,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/categories_enum.rb
+++ b/lib/merge_ticketing_client/models/categories_enum.rb
@@ -41,7 +41,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/category_enum.rb
+++ b/lib/merge_ticketing_client/models/category_enum.rb
@@ -41,7 +41,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/encoding_enum.rb
+++ b/lib/merge_ticketing_client/models/encoding_enum.rb
@@ -39,7 +39,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/issue_status_enum.rb
+++ b/lib/merge_ticketing_client/models/issue_status_enum.rb
@@ -38,7 +38,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/method_enum.rb
+++ b/lib/merge_ticketing_client/models/method_enum.rb
@@ -43,7 +43,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/priority_enum.rb
+++ b/lib/merge_ticketing_client/models/priority_enum.rb
@@ -40,7 +40,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/request_format_enum.rb
+++ b/lib/merge_ticketing_client/models/request_format_enum.rb
@@ -39,7 +39,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/response_type_enum.rb
+++ b/lib/merge_ticketing_client/models/response_type_enum.rb
@@ -38,7 +38,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/sync_status_status_enum.rb
+++ b/lib/merge_ticketing_client/models/sync_status_status_enum.rb
@@ -41,7 +41,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/lib/merge_ticketing_client/models/ticket_status_enum.rb
+++ b/lib/merge_ticketing_client/models/ticket_status_enum.rb
@@ -40,7 +40,7 @@ module MergeTicketingClient
     end
 
     def self.build_from_hash(value)
-      IssueStatusEnum.new.build_from_hash(value)
+      new.build_from_hash(value)
     end
   end
 

--- a/spec/models/account_details_and_actions_status_enum_spec.rb
+++ b/spec/models/account_details_and_actions_status_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::AccountDetailsAndActionsStatusEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::AccountDetailsAndActionsStatusEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[COMPLETE INCOMPLETE RELINK_NEEDED] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/categories_enum_spec.rb
+++ b/spec/models/categories_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::CategoriesEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::CategoriesEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[hris ats accounting ticketing crm] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/category_enum_spec.rb
+++ b/spec/models/category_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::CategoryEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::CategoryEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[hris ats accounting ticketing crm] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/encoding_enum_spec.rb
+++ b/spec/models/encoding_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::EncodingEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::EncodingEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[RAW BASE64 GZIP_BASE64] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/issue_status_enum_spec.rb
+++ b/spec/models/issue_status_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::IssueStatusEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::IssueStatusEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[ONGOING RESOLVED] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/method_enum_spec.rb
+++ b/spec/models/method_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::MethodEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::MethodEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[GET OPTIONS HEAD POST PUT PATCH DELETE] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/priority_enum_spec.rb
+++ b/spec/models/priority_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::PriorityEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::PriorityEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[URGENT HIGH NORMAL LOW] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/request_format_enum_spec.rb
+++ b/spec/models/request_format_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::RequestFormatEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::RequestFormatEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[JSON XML MULTIPART] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/response_type_enum_spec.rb
+++ b/spec/models/response_type_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::ResponseTypeEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::ResponseTypeEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[JSON BASE64_GZIP] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/sync_status_status_enum_spec.rb
+++ b/spec/models/sync_status_status_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::SyncStatusStatusEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::SyncStatusStatusEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[SYNCING DONE FAILED DISABLED PAUSED] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end

--- a/spec/models/ticket_status_enum_spec.rb
+++ b/spec/models/ticket_status_enum_spec.rb
@@ -25,4 +25,28 @@ describe MergeTicketingClient::TicketStatusEnum do
       expect(instance).to be_instance_of(MergeTicketingClient::TicketStatusEnum)
     end
   end
+
+  describe '#build_from_hash' do
+    context 'value is a standard value' do
+      let(:standard_values) { %w[OPEN CLOSED IN_PROGRESS ON_HOLD] }
+
+      it 'sets the raw_value and the value for the instance to be the value passed in' do
+        standard_values.each do |value|
+          instance.build_from_hash(value)
+          expect(instance.raw_value).to eq(value)
+          expect(instance.value).to eq(value)
+        end
+      end
+    end
+
+    context 'value is not a standard value' do
+      let(:nonstandard_value) { "something else" }
+
+      it 'sets the raw_value for the instance to be the value passed in, but casts its value to be marked as nonstandard' do
+        instance.build_from_hash(nonstandard_value)
+        expect(instance.raw_value).to eq(nonstandard_value)
+        expect(instance.value).to eq("MERGE_NONSTANDARD_VALUE")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of the change

This PR removes the reference to the `IssueStatusEnum` class in the `build_from_hash` class method for all the enum models. Previously, an instance of `MergeTicketingClient::IssueStatusEnum` was created any time this method was called for one of these classes. Now, the class will be utilizing itself to build the instance, allowing the proper casting of `raw_value` to `value` to appear in results for the APIs when dealing with these enums.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
